### PR TITLE
Run go tests on Windows

### DIFF
--- a/imls-raspberry-pi/Makefile
+++ b/imls-raspberry-pi/Makefile
@@ -1,12 +1,16 @@
 VERSION := $(shell git describe --tags --abbrev=0)
 LDFLAGS = "-X gsa.gov/18f/version.Semver=$(VERSION)"
+RELEASEPATH = ../release/bin/*
 
 ifeq ($(shell uname -m),armv7l)
-RELEASEPATH = ../release/bin/*
 ENVVARS = CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7
 else
-RELEASEPATH = ../release/bin/linux_arm/*
+ifeq ($(OS),Windows_NT)
+# choco install mingw (for now, since we need CGO)
+ENVVARS = CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin/x86_64-w64-mingw32-gcc
+else
 ENVVARS = CGO_ENABLED=1 GOOS=linux
+endif
 endif
 
 check-install:

--- a/imls-raspberry-pi/cmd/session-counter/Makefile
+++ b/imls-raspberry-pi/cmd/session-counter/Makefile
@@ -13,7 +13,7 @@ install: all
 test:
 	go test api/*.go
 	go test model/*.go
-	go test -timeout 10m *.go
+	go test -timeout 60m *.go
 
 crossbuild: clean
 	GOOS=linux GOARCH=arm GOARM=7 go build

--- a/imls-raspberry-pi/cmd/session-counter/tlp/shark_test.go
+++ b/imls-raspberry-pi/cmd/session-counter/tlp/shark_test.go
@@ -36,8 +36,11 @@ func cleanupTempFiles() {
 	}
 }
 func setup() {
-	configPath := "/tmp/test-shark.sqlite"
-	state.SetConfigAtPath(configPath)
+	tempDB, err := os.CreateTemp("", "shark-test.sqlite")
+	if err != nil {
+		log.Fatal(err)
+	}
+	state.SetConfigAtPath(tempDB.Name())
 	cfg := state.GetConfig()
 	cfg.SetRunMode("test")
 	cfg.SetStorageMode("sqlite")

--- a/imls-raspberry-pi/cmd/session-counter/tlp/tlp_test.go
+++ b/imls-raspberry-pi/cmd/session-counter/tlp/tlp_test.go
@@ -28,15 +28,14 @@ type TLPSuite struct {
 	lw   *logwrapper.StandardLogger
 }
 
-var tlpDBPath = "/tmp/config-test.sql"
-
 // Make sure that VariableThatShouldStartAtFive is set to five
 // before each test
 func (suite *TLPSuite) SetupTest() {
-
-	os.Create(tlpDBPath)
-	os.Chmod(tlpDBPath, 0777)
-	state.SetConfigAtPath(tlpDBPath)
+	tempDB, err := os.CreateTemp("", "tlp-test.sqlite")
+	if err != nil {
+		suite.Fail(err.Error())
+	}
+	state.SetConfigAtPath(tempDB.Name())
 
 	cfg := state.GetConfig()
 	cfg.SetRunMode("test")
@@ -70,9 +69,9 @@ func (suite *TLPSuite) SetupTest() {
 
 func (suite *TLPSuite) AfterTest(suiteName, testName string) {
 	dc := state.GetConfig()
-	dc.Close()
 	// ensure a clean run.
-	os.Remove(tlpDBPath)
+	os.Remove(dc.GetDatabasePath())
+	dc.Close()
 }
 
 func generateFakeMac() string {

--- a/imls-raspberry-pi/internal/state/config.go
+++ b/imls-raspberry-pi/internal/state/config.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/base64"
 	"log"
+	"runtime"
 	"strings"
 	"time"
 
@@ -298,8 +299,6 @@ func ConfigDefaults() ConfigDB {
 	// Serial filled in by device or user
 	defaults.storageMode = "api"
 	defaults.runMode = "prod"
-	defaults.durationsPath = "/www/imls/durations.sqlite"
-	defaults.queuesPath = "/www/imls/queues.sqlite"
 	defaults.umbrellaScheme = "https"
 	defaults.umbrellaHost = "api.data.gov"
 	defaults.eventsURI = "/TEST/10x-imls/v2/events/"
@@ -307,9 +306,19 @@ func ConfigDefaults() ConfigDB {
 	defaults.minimumMinutes = 5
 	defaults.maximumMinutes = 600
 	defaults.wiresharkDuration = 45
-	defaults.wiresharkPath = "/usr/bin/tshark"
 	defaults.resetCron = "0 0 * * *"
-	defaults.wwwRoot = "/www/imls"
-	defaults.wwwImages = "/www/imls/images"
+	if runtime.GOOS == "windows" {
+		defaults.wiresharkPath = "c:/Program Files/Wireshark/bin/tshark.exe"
+		defaults.wwwRoot = "c:/imls"
+		defaults.wwwImages = "c:/imls/images"
+		defaults.durationsPath = "c:/imls/durations.sqlite"
+		defaults.queuesPath = "c:/imls/queues.sqlite"
+	} else {
+		defaults.wiresharkPath = "/usr/bin/tshark"
+		defaults.wwwRoot = "/www/imls"
+		defaults.wwwImages = "/www/imls/images"
+		defaults.durationsPath = "/www/imls/durations.sqlite"
+		defaults.queuesPath = "/www/imls/queues.sqlite"
+	}
 	return defaults
 }

--- a/imls-raspberry-pi/internal/state/config.go
+++ b/imls-raspberry-pi/internal/state/config.go
@@ -218,6 +218,10 @@ func (dc *databaseConfig) GetDurationsDatabase() interfaces.Database {
 	return db
 }
 
+func (dc *databaseConfig) GetDatabasePath() string {
+	return dc.configDB.GetPath()
+}
+
 func (dc *databaseConfig) GetQueuesDatabase() interfaces.Database {
 	path := dc.config.GetTextField("queues_path")
 	return NewSqliteDB(path)

--- a/imls-raspberry-pi/internal/state/config_test.go
+++ b/imls-raspberry-pi/internal/state/config_test.go
@@ -13,19 +13,19 @@ type ConfigSuite struct {
 	suite.Suite
 }
 
-var configDBPath = "/tmp/config-test.sql"
-
 func (suite *ConfigSuite) SetupTest() {
-	os.Create(configDBPath)
-	os.Chmod(configDBPath, 0777)
-	SetConfigAtPath(configDBPath)
+	tempDB, err := os.CreateTemp("", "config-test.sqlite")
+	if err != nil {
+		suite.Fail(err.Error())
+	}
+	SetConfigAtPath(tempDB.Name())
 }
 
 func (suite *ConfigSuite) AfterTest(suiteName, testName string) {
 	dc := GetConfig()
-	dc.Close()
 	// ensure a clean run.
-	os.Remove(configDBPath)
+	os.Remove(dc.GetDatabasePath())
+	dc.Close()
 }
 
 func (suite *ConfigSuite) TestConfigDefaults() {

--- a/imls-raspberry-pi/internal/state/list_test.go
+++ b/imls-raspberry-pi/internal/state/list_test.go
@@ -10,19 +10,19 @@ type ListSuite struct {
 	suite.Suite
 }
 
-var listDBPath = "/tmp/config-list.sql"
-
 func (suite *ListSuite) SetupTest() {
-	os.Create(listDBPath)
-	os.Chmod(listDBPath, 0777)
-	SetConfigAtPath(listDBPath)
+	tempDB, err := os.CreateTemp("", "list-test.sqlite")
+	if err != nil {
+		suite.Fail(err.Error())
+	}
+	SetConfigAtPath(tempDB.Name())
 }
 
 func (suite *ListSuite) AfterTest(suiteName, testName string) {
 	dc := GetConfig()
-	dc.Close()
 	// ensure a clean run.
-	os.Remove(listDBPath)
+	os.Remove(dc.GetDatabasePath())
+	dc.Close()
 }
 
 func (suite *ListSuite) TestList() {

--- a/imls-raspberry-pi/internal/state/queue_test.go
+++ b/imls-raspberry-pi/internal/state/queue_test.go
@@ -10,19 +10,19 @@ type QueueSuite struct {
 	suite.Suite
 }
 
-var suiteDBPath = "/tmp/config-suite.sql"
-
 func (suite *QueueSuite) SetupTest() {
-	os.Create(suiteDBPath)
-	os.Chmod(suiteDBPath, 0777)
-	SetConfigAtPath(suiteDBPath)
+	tempDB, err := os.CreateTemp("", "queue-test.sqlite")
+	if err != nil {
+		suite.Fail(err.Error())
+	}
+	SetConfigAtPath(tempDB.Name())
 }
 
 func (suite *QueueSuite) AfterTest(suiteName, testName string) {
 	dc := GetConfig()
-	dc.Close()
 	// ensure a clean run.
-	os.Remove(suiteDBPath)
+	os.Remove(dc.GetDatabasePath())
+	dc.Close()
 }
 
 func (suite *QueueSuite) TestQueueCreate() {

--- a/imls-raspberry-pi/internal/state/sqlitedb_test.go
+++ b/imls-raspberry-pi/internal/state/sqlitedb_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"log"
+	"os"
 	"testing"
 	"time"
 
@@ -36,21 +37,36 @@ func AsApples(is []interface{}) []Apple {
 }
 
 func TestSqliteDB(test *testing.T) {
-	d := NewSqliteDB("/tmp/test.sqlite")
+	tempDB, err := os.CreateTemp("", "sqlitedb-test-db")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tempDB.Name())
+	d := NewSqliteDB(tempDB.Name())
 	t := d.InitTable("oranges")
 	t.AddColumn("count", t.GetIntegerType())
 	t.Create()
 }
 
 func TestSqliteDB2(test *testing.T) {
-	d := NewSqliteDB("/tmp/test.sqlite")
+	tempDB, err := os.CreateTemp("", "sqlitedb-test-db2")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tempDB.Name())
+	d := NewSqliteDB(tempDB.Name())
 	t := d.CreateTableFromStruct(Apple{})
 	t.InsertStruct(Apple{Color: "red", Weight: 3})
 	t.InsertStruct(Apple{Color: "green", Weight: 5})
 }
 
 func TestSelectAll(test *testing.T) {
-	d := NewSqliteDB("/tmp/test.sqlite")
+	tempDB, err := os.CreateTemp("", "sqlitedb-test-select-all")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tempDB.Name())
+	d := NewSqliteDB(tempDB.Name())
 	t := d.CreateTableFromStruct(Apple{})
 	t.InsertStruct(Apple{Color: "red", Weight: 3})
 	apples := Apple{}.SelectAll(t.GetDB())
@@ -76,14 +92,19 @@ func TestSelectAll(test *testing.T) {
 }
 
 func TestManyOpens(test *testing.T) {
+	tempDB, err := os.CreateTemp("", "sqlitedb-test-many-opens")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tempDB.Name())
 	go http.ListenAndServe("localhost:8080", nil)
 	for i := 0; i < 8000; i++ {
-		d := NewSqliteDB("/tmp/test.sqlite")
+		d := NewSqliteDB(tempDB.Name())
 		d.CreateTableFromStruct(Apple{})
 	}
 	time.Sleep(10 * time.Second)
 	for i := 0; i < 16000; i++ {
-		d := NewSqliteDB("/tmp/test.sqlite")
+		d := NewSqliteDB(tempDB.Name())
 		d.CreateTableFromStruct(Apple{})
 	}
 }


### PR DESCRIPTION
This PR enables us to run tests on Windows. `session-counter.exe` does not work because we have yet to refactor the wifi hardware search functionality to work on Windows. 

Timeout for s-c tests was bumped up because (on my Windows instance) it takes `2473.839s` to finish.

To run these tests, I install `make` **and** `mingw` via chocolatey. 